### PR TITLE
Fixed target linking order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,14 +6,14 @@ include_directories("lua/src")
 
 list( APPEND CMAKE_CXX_FLAGS "-std=c++0x ${CMAKE_CXX_FLAGS} -g -ftest-coverage -fprofile-arcs")
 
-target_link_libraries(LuaCppInterface lua)
-
-add_library(luacppinterface STATIC 
-	LuaCppInterface/luacoroutine.cpp
-	LuaCppInterface/luareference.cpp
-	LuaCppInterface/luacppinterface.cpp
-	LuaCppInterface/luatable.cpp
-	LuaCppInterface/luafunction.cpp
-	LuaCppInterface/luaerror.cpp
-	LuaCppInterface/luastringconversion.cpp
+add_library(luacppinterface STATIC
+    LuaCppInterface/luacoroutine.cpp
+    LuaCppInterface/luareference.cpp
+    LuaCppInterface/luacppinterface.cpp
+    LuaCppInterface/luatable.cpp
+    LuaCppInterface/luafunction.cpp
+    LuaCppInterface/luaerror.cpp
+    LuaCppInterface/luastringconversion.cpp
 )
+
+target_link_libraries(luacppinterface lua)


### PR DESCRIPTION
Fixed 

```
CMake Error at luacppinterface-master/CMakeLists.txt:9 (target_link_libraries):
  Cannot specify link libraries for target "LuaCppInterface" which is not
  built by this project.
```

error